### PR TITLE
Fix test failures without '.' in @INC on Perl 5.26

### DIFF
--- a/t/Module-Info.t
+++ b/t/Module-Info.t
@@ -203,8 +203,8 @@ SKIP: {
     my @mods = $module->modules_used;
     is( @mods, 8,           'modules_used' );
     is_deeply( [sort @mods],
-               [sort qw(strict vars Carp Exporter t/lib/Bar.pm t/lib/NotHere.pm
-                        t/lib/Foo.pm lib)] );
+               [sort qw(strict vars Carp Exporter ./t/lib/Bar.pm ./t/lib/NotHere.pm
+                        ./t/lib/Foo.pm lib)] );
 
     $module->name('Foo');
     my @isa = $module->superclasses;

--- a/t/lib/Foo.pm
+++ b/t/lib/Foo.pm
@@ -2,7 +2,7 @@ package Foo;
 
 use strict;
 require Exporter;
-require "t/lib/Foo.pm";
+require "./t/lib/Foo.pm";
 use vars qw(@ISA $VERSION);
 $VERSION = 7.254;
 
@@ -56,13 +56,13 @@ sub croak {
 
     return sub {
         main::wibble('call insde anon sub inside sub');
-        require 't/lib/NotHere.pm';
+        require './t/lib/NotHere.pm';
     }
 }
 
 BEGIN {
-    require 't/lib/Bar.pm';
+    require './t/lib/Bar.pm';
 }
 
-my $mod = 't/lib/Bar.pm';
+my $mod = './t/lib/Bar.pm';
 require $mod;


### PR DESCRIPTION
Where: PERL_USE_UNSAFE_INC=0

Bug: https://bugs.gentoo.org/617110
Bug: https://rt.cpan.org/Ticket/Display.html?id=121035